### PR TITLE
chore: Add concurrently to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     ]
   },
   "devDependencies": {
+    "concurrently": "^7.3.0",
     "nodemon": "^2.0.19"
   }
 }


### PR DESCRIPTION
concurrently was used in `npm run start` script.
but not added to dev dependencies.